### PR TITLE
Support cni configs using WithConfig

### DIFF
--- a/libcni.go
+++ b/libcni.go
@@ -2,8 +2,6 @@ package libcni
 
 import (
 	"fmt"
-	"sort"
-	"strings"
 
 	cnilibrary "github.com/containernetworking/cni/libcni"
 	"github.com/containernetworking/cni/pkg/types/current"
@@ -36,79 +34,22 @@ func defaultCNIConfig() *libcni {
 	}
 }
 
-func New(config ...ConfigOptions) CNI {
+func New(config ...ConfigOptions) (CNI, error) {
 	cni := defaultCNIConfig()
 	cni.cniConfig = &cnilibrary.CNIConfig{Path: cni.pluginDirs}
 	for _, c := range config {
-		c(cni)
+		if err := c(cni); err != nil {
+			return nil, err
+		}
 	}
-	cni.populateNetworkConfig()
-	return cni
+	return cni, nil
 }
 
 func (c *libcni) Status() error {
 	// TODO this logic changes when CNI Supports
 	// Dynamic network updates
 	if len(c.networks) < c.networkCount {
-		c.populateNetworkConfig()
-	}
-
-	if len(c.networks) < c.networkCount {
 		return fmt.Errorf("cni config not intialized")
-	}
-	return nil
-}
-
-func (c *libcni) populateNetworkConfig() error {
-	files, err := cnilibrary.ConfFiles(c.pluginConfDir, []string{".conf", ".conflist", ".json"})
-	switch {
-	case err != nil:
-		return err
-	case len(files) == 0:
-		return fmt.Errorf("No network config found in %s", c.pluginConfDir)
-	}
-	// files contains the network config files associated with cni network.
-	// Use lexicographical way as a defined order for network config files.
-	sort.Strings(files)
-
-	for _, confFile := range files {
-		var confList *cnilibrary.NetworkConfigList
-		if strings.HasSuffix(confFile, ".conflist") {
-			confList, err = cnilibrary.ConfListFromFile(confFile)
-			if err != nil {
-				fmt.Errorf("Error loading CNI config list file %s: %v", confFile, err)
-				continue
-			}
-		} else {
-			conf, err := cnilibrary.ConfFromFile(confFile)
-			if err != nil {
-				fmt.Errorf("Error loading CNI config file %s: %v", confFile, err)
-				continue
-			}
-			// Ensure the config has a "type" so we know what plugin to run.
-			// Also catches the case where somebody put a conflist into a conf file.
-			if conf.Network.Type == "" {
-				fmt.Errorf("Error loading CNI config file %s: no 'type'; perhaps this is a .conflist?", confFile)
-				continue
-			}
-
-			confList, err = cnilibrary.ConfListFromConf(conf)
-			if err != nil {
-				fmt.Errorf("Error converting CNI config file %s to list: %v", confFile, err)
-				continue
-			}
-		}
-		if len(confList.Plugins) == 0 {
-			fmt.Errorf("CNI config list %s has no networks, skipping", confFile)
-			continue
-		}
-		c.networks = append(c.networks, &Network{
-			cni:    c.cniConfig,
-			config: confList,
-		})
-	}
-	if len(c.networks) == 0 {
-		return fmt.Errorf("No valid networks found in %s", c.pluginDirs)
 	}
 	return nil
 }

--- a/opts.go
+++ b/opts.go
@@ -1,6 +1,10 @@
 package libcni
 
 import (
+	"fmt"
+	"sort"
+	"strings"
+
 	cnilibrary "github.com/containernetworking/cni/libcni"
 )
 
@@ -23,6 +27,60 @@ func WithPluginDir(dirs []string) ConfigOptions {
 func WithPluginConfDir(dir string) ConfigOptions {
 	return func(c *libcni) error {
 		c.pluginConfDir = dir
+		return nil
+	}
+}
+
+func WithDefaultConfig() ConfigOptions {
+	return func(c *libcni) error {
+		files, err := cnilibrary.ConfFiles(c.pluginConfDir, []string{".conf", ".conflist", ".json"})
+		switch {
+		case err != nil:
+			return err
+		case len(files) == 0:
+			return fmt.Errorf("No network config found in %s", c.pluginConfDir)
+		}
+		// files contains the network config files associated with cni network.
+		// Use lexicographical way as a defined order for network config files.
+		sort.Strings(files)
+
+		for _, confFile := range files {
+			var confList *cnilibrary.NetworkConfigList
+			if strings.HasSuffix(confFile, ".conflist") {
+				confList, err = cnilibrary.ConfListFromFile(confFile)
+				if err != nil {
+					fmt.Errorf("Error loading CNI config list file %s: %v", confFile, err)
+					continue
+				}
+			} else {
+				conf, err := cnilibrary.ConfFromFile(confFile)
+				if err != nil {
+					fmt.Errorf("Error loading CNI config file %s: %v", confFile, err)
+					continue
+				}
+				// Ensure the config has a "type" so we know what plugin to run.
+				// Also catches the case where somebody put a conflist into a conf file.
+				if conf.Network.Type == "" {
+					fmt.Errorf("Error loading CNI config file %s: no 'type'; perhaps this is a .conflist?", confFile)
+					continue
+				}
+
+				confList, err = cnilibrary.ConfListFromConf(conf)
+				if err != nil {
+					fmt.Errorf("Error converting CNI config file %s to list: %v", confFile, err)
+					continue
+				}
+			}
+			if len(confList.Plugins) == 0 {
+				fmt.Errorf("CNI config list %s has no networks, skipping", confFile)
+				continue
+			}
+			c.networks = append(c.networks, &Network{
+				cni:    c.cniConfig,
+				config: confList,
+			})
+		}
+
 		return nil
 	}
 }
@@ -51,14 +109,24 @@ func WithMinNetworkCount(count int) ConfigOptions {
 	}
 }
 
-//TODO: Should we support direct network configs?
-/*
-func WithConf(byte []bytes) ConfigOptions {
-	return func(c *config) error {
+func WithConfig(b []byte) ConfigOptions {
+	return func(c *libcni) error {
+		cfg, err := cnilibrary.ConfListFromBytes(b)
+		if err != nil {
+			return err
+		}
 
+		c.networks = append(c.networks, &Network{
+			cni:    c.cniConfig,
+			config: cfg,
+		})
+
+		return nil
 	}
 }
 
+//TODO: Should we support direct network configs?
+/*
 func WithConfFile(fileName string) ConfigOptions {
 	return func(c *config) error {
 


### PR DESCRIPTION
This adds `WithConfig` to specify CNI configs instead of using the defaults.  This also moves the `populateNetworkConfig` logic to a `WithDefaultConfig` that can be used to load in the default configuration from the directory.